### PR TITLE
Add React 17 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
There are no differences in functionality between React 16 and 17 so we should be safe to include React 17 as a valid peer dependency.